### PR TITLE
artstack-downloader 1.4.1 Added badges

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-15 Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)
+Copyright (c) 2014-16 Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-# artstack-downloader [![Support this project][donate-now]][paypal-donations]
+# artstack-downloader [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/artstack-downloader.svg)](https://www.npmjs.com/package/artstack-downloader) [![Downloads](https://img.shields.io/npm/dt/artstack-downloader.svg)](https://www.npmjs.com/package/artstack-downloader) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
-Download artworks from your following users.
+> Download artworks from your following users.
 
 ## Installation
 
 ```sh
 $ npm i --save artstack-downloader
 ```
-
-## Documentation
 
 ## How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artstack-downloader",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Download artworks from your following users.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
- Added badges :tada:
  - [PayPal Donations](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RVXDDLKKLQRJW)
  - npm downloads
  - npm version
  - Travis (if there are tests)
  - [CodeMentor](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)–you can ping me there if you need help with one of these modules (or help in general).
- Updated the LICENSE year. :fireworks:
