### PR TITLE
artstack-downloader 1.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# artstack-downloader [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/artstack-downloader.svg)](https://www.npmjs.com/package/artstack-downloader) [![Downloads](https://img.shields.io/npm/dt/artstack-downloader.svg)](https://www.npmjs.com/package/artstack-downloader) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# artstack-downloader
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/artstack-downloader.svg)](https://www.npmjs.com/package/artstack-downloader) [![Downloads](https://img.shields.io/npm/dt/artstack-downloader.svg)](https://www.npmjs.com/package/artstack-downloader) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Download artworks from your following users.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artstack-downloader",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Download artworks from your following users.",
   "main": "index.js",
   "dependencies": {
@@ -36,6 +36,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
